### PR TITLE
Make necessary changes for Python 3 in joint_control

### DIFF
--- a/joint_control/add_training_data.ipynb
+++ b/joint_control/add_training_data.ipynb
@@ -85,7 +85,7 @@
     "\n",
     "pose_name = 'Back'\n",
     "data_file = path.join('robot_pose_data', pose_name)\n",
-    "data = pickle.load(open(data_file))"
+    "data = pickle.load(open(data_file, 'rb'))"
    ]
   },
   {
@@ -102,7 +102,7 @@
     }
    ],
    "source": [
-    "print data"
+    "print(data)"
    ]
   },
   {
@@ -122,7 +122,7 @@
    "source": [
     "new_data = [0, 0, 0, 0, 0, 0, 0, 0, 0, -1.5707963267948966]\n",
     "data.append(new_data)\n",
-    "pickle.dump(data, open(data_file, 'w'))"
+    "pickle.dump(data, open(data_file, 'wb'))"
    ]
   },
   {

--- a/joint_control/keyframes/__init__.py
+++ b/joint_control/keyframes/__init__.py
@@ -1,10 +1,10 @@
 '''Keyframes from Aldebaran
 '''
 
-from leftBackToStand import leftBackToStand
-from leftBellyToStand import leftBellyToStand
-from rightBackToStand import rightBackToStand
-from rightBellyToStand import rightBellyToStand
+from keyframes.leftBackToStand import leftBackToStand
+from keyframes.leftBellyToStand import leftBellyToStand
+from keyframes.rightBackToStand import rightBackToStand
+from keyframes.rightBellyToStand import rightBellyToStand
 
-from hello import hello
-from wipe_forehead import wipe_forehead
+from keyframes.hello import hello
+from keyframes.wipe_forehead import wipe_forehead

--- a/joint_control/learn_posture.ipynb
+++ b/joint_control/learn_posture.ipynb
@@ -84,8 +84,8 @@
     }
    ],
    "source": [
-    "classes = listdir(ROBOT_POSE_DATA_DIR)\n",
-    "print classes"
+    "classes = sorted(listdir(ROBOT_POSE_DATA_DIR))\n",
+    "print(classes)"
    ]
   },
   {
@@ -103,7 +103,7 @@
     "    # YOUR CODE HERE\n",
     "    \n",
     "    filename = path.join(ROBOT_POSE_DATA_DIR, classes[i])\n",
-    "    data = pickle.load(open(filename))\n",
+    "    data = pickle.load(open(filename, 'rb'))\n",
     "    target = [i] * len(data)\n",
     "    return data, target"
    ]
@@ -119,7 +119,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "total number of data 200\n"
+      "Loaded 222 items\n"
      ]
     }
    ],
@@ -129,21 +129,35 @@
     "all_target = []\n",
     "# YOUR CODE HERE\n",
     "\n",
-    "print 'total number of data', len(all_data)"
+    "print(f\"Loaded {len(all_data)} items\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 86,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Using 155 items for training and 67 for testing\n"
+     ]
+    }
+   ],
    "source": [
-    "# shuffule data\n",
+    "# shuffle data\n",
     "permutation = np.random.permutation(len(all_data))\n",
+    "shuffled_data = [all_data[i] for i in permutation]\n",
+    "shuffled_target = [all_target[i] for i in permutation]\n",
     "n_training_data = int(len(all_data) * 0.7)\n",
-    "training_data = permutation[:n_training_data]"
+    "\n",
+    "training_data = shuffled_data[:n_training_data]\n",
+    "training_target = shuffled_target[:n_training_data]\n",
+    "testing_data = shuffled_data[n_training_data:]\n",
+    "testing_target = shuffled_target[n_training_data:]\n",
+    "\n",
+    "print(f\"Using {len(training_data)} items for training and {len(testing_data)} for testing\")"
    ]
   },
   {
@@ -214,7 +228,7 @@
     {
      "data": {
       "text/plain": [
-       "(array([10]), 10)"
+       "(array([10]), [10])"
       ]
      },
      "execution_count": 58,
@@ -223,7 +237,7 @@
     }
    ],
    "source": [
-    "clf.predict(all_data[-1]), all_target[-1]"
+    "clf.predict(all_data[-1:]), all_target[-1:]"
    ]
   },
   {
@@ -370,7 +384,7 @@
    "source": [
     "import pickle\n",
     "ROBOT_POSE_CLF = 'robot_pose.pkl'\n",
-    "pickle.dump(clf, open(ROBOT_POSE_CLF, 'w'))"
+    "pickle.dump(clf, open(ROBOT_POSE_CLF, 'wb'))"
    ]
   },
   {
@@ -390,7 +404,7 @@
     {
      "data": {
       "text/plain": [
-       "(array([10]), 10)"
+       "(array([10]), [10])"
       ]
      },
      "execution_count": 71,
@@ -399,8 +413,8 @@
     }
    ],
    "source": [
-    "clf2 = pickle.load(open(ROBOT_POSE_CLF))\n",
-    "clf2.predict(all_data[-1]), all_target[-1]"
+    "clf2 = pickle.load(open(ROBOT_POSE_CLF, 'rb'))\n",
+    "clf2.predict(all_data[-1:]), all_target[-1:]"
    ]
   },
   {

--- a/software_installation/sexpr.py
+++ b/software_installation/sexpr.py
@@ -1,10 +1,8 @@
-#!/usr/bin/env python
 ##
 ##  sexpr.py - by Yusuke Shinyama
 ##
 ##  * public domain *
 ##
-import future
 
 ##  AbstractFilter
 ##


### PR DESCRIPTION
The changes have intentionally been kept minimal to make them easier to verify. The Notebooks would likely benefit from a re-run afterwards though, to upgrade their internal version numbers.

The fixes are as follows:
- `print(data)` instead of `print data`, as print became a function in Python 3 instead of a keyword. Also f-Strings have been used, assuming a non-EOL-Python (supported since 3.6), since they are shorter than a `.format()`.
- `open(filename, 'rb')` for `pickle.load` since the latter requires a function returning bytes instead of strings so the file has to be opened in binary mode.
- The imports in __init__.py have to be changed to be relative to the base module name. Otherwise just a `ModuleNotFoundError: No module named 'hello'` results.
- In sexpr.py the `import future` has been dropped since it is obsolete and unused and the shebang has been dropped since the file has no main function.
- In learn_posture.ipynb it has been noticed, that the `listdir()`-Function returns a list in arbitrary (undefined and may change from run to run) order. This has been resolved by simply sorting it.